### PR TITLE
Invoke parent class constructor (SUPER::new)

### DIFF
--- a/lib/WebService/RTMAgent.pm
+++ b/lib/WebService/RTMAgent.pm
@@ -109,10 +109,11 @@ Creates a new agent.
 =cut
 
 sub new {
-    my ($class) = @_;
-    my $self = bless {}, $class;
+    my $proto = shift;
+    my $class = ref($proto) || $proto;
+    my $self  = $class->SUPER::new(@_);
     $self->verbose('');
-    return $self;
+    return bless $self, $class;
 }
 
 =head2 $ua->api_key($key);


### PR DESCRIPTION
Proximate reason is this warning in LWP::UserAgent 6.50.0(*)

   Use of uninitialized value in numeric ge (>=) at /usr/lib64/perl5/vendor_perl/5.20.1/LWP/UserAgent.pm line 285.
   Use of uninitialized value in concatenation (.) or string at /usr/lib64/perl5/vendor_perl/5.20.1/LWP/UserAgent.pm line 286.

This is because LWP::UserAgent::request() references $self->{max_redirect}
which is initialized in the constructor. We could just hardcode the same
initialization into WebService::RTMAgent::new(), but this is cleaner and
more futureproof.

(*) 6.50.0 on gentoo. There is no such version on CPAN. I don't get it
    either, but FWIW 6.13 on CPAN shows the same issue.

Signed-off-by: Ed Santiago esm@cpan.org
